### PR TITLE
feat: 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 }
 
 dependencies {
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/isuisu/sign/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/isuisu/sign/configuration/WebSecurityConfig.java
@@ -1,7 +1,15 @@
 package com.isuisu.sign.configuration;
 
+import com.isuisu.sign.security.CustomUserDetailsService;
+import com.isuisu.sign.security.JwtAuthenticationFilter;
+import com.isuisu.sign.security.JwtAuthorizationFilter;
+import com.isuisu.sign.security.JwtTokenService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -9,21 +17,31 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final CustomUserDetailsService userDetailsService;
+    private final JwtTokenService jwtTokenService;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/signup", "/api/signin").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/signup", "/api/signin").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 );
+
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterAfter(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
 
         return http.build();
     }
@@ -32,4 +50,22 @@ public class WebSecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenService);
+        filter.setAuthenticationManager(authenticationManager());
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtTokenService, userDetailsService);
+    }
+
 }

--- a/src/main/java/com/isuisu/sign/controller/SignController.java
+++ b/src/main/java/com/isuisu/sign/controller/SignController.java
@@ -1,15 +1,16 @@
 package com.isuisu.sign.controller;
 
+import com.isuisu.sign.dto.SignInRequestDto;
+import com.isuisu.sign.dto.SignInResponseDto;
 import com.isuisu.sign.dto.SignUpRequestDto;
 import com.isuisu.sign.dto.SignUpResponseDto;
 import com.isuisu.sign.service.SignService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api")
@@ -24,5 +25,25 @@ public class SignController {
     ) {
 
         return ResponseEntity.ok(signService.signup(userDto));
+    }
+
+    /**
+     * JwtAuthenticationFilter 에서 로그인 진행 <p>
+     * 해당 컨트롤러에서 실행되지 않습니다. Endpoint 만 만들어 둠.
+     * @param userDto
+     * @return SignInResponseDto
+     */
+    @PostMapping("/signin")
+    public ResponseEntity<SignInResponseDto> signin(
+            @RequestBody @Valid SignInRequestDto userDto
+    ) {
+
+        return ResponseEntity.ok(new SignInResponseDto("token"));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<String> whoami(Principal principal) {
+
+        return ResponseEntity.ok(principal.getName());
     }
 }

--- a/src/main/java/com/isuisu/sign/dto/SignInRequestDto.java
+++ b/src/main/java/com/isuisu/sign/dto/SignInRequestDto.java
@@ -1,0 +1,17 @@
+package com.isuisu.sign.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignInRequestDto(
+        @NotBlank(message = "아이디는 필수로 입력되어야 합니다.")
+        @Size(min = 4, max = 20, message = "아이디는 4자 이상, 20자 이하로 입력해야 합니다.")
+        String username,
+        @NotBlank
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*[!@#$%^*+=\\-])(?=.*[0-9]).{8,}$",
+                message = "비밀번호는 알파벳 대소문자(A~Z, a~z), 특수문자, 숫자(0~9), " +
+                        "최소 8자 이상으로 이루어져 있어야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/com/isuisu/sign/dto/SignInResponseDto.java
+++ b/src/main/java/com/isuisu/sign/dto/SignInResponseDto.java
@@ -1,0 +1,6 @@
+package com.isuisu.sign.dto;
+
+public record SignInResponseDto(
+        String token
+) {
+}

--- a/src/main/java/com/isuisu/sign/model/RefreshToken.java
+++ b/src/main/java/com/isuisu/sign/model/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.isuisu.sign.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/isuisu/sign/model/UserRole.java
+++ b/src/main/java/com/isuisu/sign/model/UserRole.java
@@ -2,5 +2,5 @@ package com.isuisu.sign.model;
 
 public enum UserRole {
     ROLE_USER,
-    ROLE_ADMIN;
+    ROLE_ADMIN
 }

--- a/src/main/java/com/isuisu/sign/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/isuisu/sign/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.isuisu.sign.repository;
+
+import com.isuisu.sign.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    boolean existsByRefreshToken(String refreshToken);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/isuisu/sign/repository/UserRepository.java
+++ b/src/main/java/com/isuisu/sign/repository/UserRepository.java
@@ -4,8 +4,12 @@ import com.isuisu.sign.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/isuisu/sign/security/CustomUserDetails.java
+++ b/src/main/java/com/isuisu/sign/security/CustomUserDetails.java
@@ -1,0 +1,40 @@
+package com.isuisu.sign.security;
+
+
+import com.isuisu.sign.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return user.getAuthorities().stream()
+                .map(role -> new SimpleGrantedAuthority(role.name()))
+                .collect(Collectors.toSet());
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/com/isuisu/sign/security/CustomUserDetailsService.java
+++ b/src/main/java/com/isuisu/sign/security/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.isuisu.sign.security;
+
+import com.isuisu.sign.model.User;
+import com.isuisu.sign.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // 4. AuthenticationProvider 가 사용
+    @Override
+    public UserDetails loadUserByUsername(String username)
+            throws UsernameNotFoundException {
+
+        User user = userRepository.findByUsername(username).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "User Not Found"));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/isuisu/sign/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/isuisu/sign/security/JwtAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package com.isuisu.sign.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.isuisu.sign.dto.SignInRequestDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtTokenService jwtTokenService;
+
+    public JwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        this.jwtTokenService = jwtTokenService;
+        setFilterProcessesUrl("/api/signin");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request, HttpServletResponse response
+    ) throws AuthenticationException {
+
+        log.info("로그인 시도");
+        try {
+            SignInRequestDto userDto = new ObjectMapper().readValue(
+                    request.getInputStream(), SignInRequestDto.class
+            );
+
+            // 1. UsernamePasswordAuthenticationToken 생성
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(
+                            userDto.username(),
+                            userDto.password()
+                    );
+
+            // 2. AuthenticationManager에 인증 요청 -> 3. AuthenticationProvider를 사용
+            return getAuthenticationManager().authenticate(authenticationToken);
+
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain, Authentication authResult
+    ) {
+
+        CustomUserDetails userDetails = (CustomUserDetails) authResult.getPrincipal();
+
+        List<String> roles = authResult.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        Map<String, String> tokenMap = jwtTokenService.createToken(
+                userDetails.getUserId(), userDetails.getUsername(), roles
+        );
+
+        try {
+            writeTokenResponse(response,
+                    tokenMap.get("accessToken"), tokenMap.get("refreshToken"));
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException failed
+    ) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private void writeTokenResponse(
+            HttpServletResponse response, String accessToken, String refreshToken
+    ) throws IOException {
+
+        String jsonResponse = String.format("{\"token\": \"%s\"}", accessToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
+
+        jwtTokenService.createRefreshTokenCookie(response, refreshToken);
+    }
+}

--- a/src/main/java/com/isuisu/sign/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/isuisu/sign/security/JwtAuthorizationFilter.java
@@ -1,0 +1,90 @@
+package com.isuisu.sign.security;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.isuisu.sign.security.JwtUtil.BEARER_PREFIX;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private final JwtTokenService jwtTokenService;
+    private final CustomUserDetailsService userDetailsService;
+
+    public JwtAuthorizationFilter(
+            JwtTokenService jwtTokenService, CustomUserDetailsService userDetailsService
+    ) {
+        this.jwtTokenService = jwtTokenService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        log.info("로그인 후 토큰으로 검증");
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        String token = jwtTokenService.validateToken(bearerToken);
+
+        // 만료된 JWT token 일 경우 -> 쿠키의 refreshToken 으로 새로운 토큰 발행
+        if (token == null) {
+            String refreshTokenFromCookies =
+                    jwtTokenService.getRefreshTokenFromCookies(request);
+            String username =
+                    jwtTokenService.getUsernameFromToken(refreshTokenFromCookies);
+            CustomUserDetails userDetails =
+                    (CustomUserDetails) userDetailsService.loadUserByUsername(username);
+            token = jwtTokenService.renewAccessTokenWithRefreshToken(
+                        refreshTokenFromCookies, userDetails);
+
+            response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
+        }
+
+        String username = jwtTokenService.getUsernameFromToken(token);
+
+        try {
+            setAuthentication(username);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            response.sendError(
+                    HttpServletResponse.SC_UNAUTHORIZED, "Authentication failed"
+            );
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    public void setAuthentication(String username) {
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    private Authentication createAuthentication(String username) {
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/isuisu/sign/security/JwtTokenService.java
+++ b/src/main/java/com/isuisu/sign/security/JwtTokenService.java
@@ -1,0 +1,99 @@
+package com.isuisu.sign.security;
+
+import com.isuisu.sign.model.RefreshToken;
+import com.isuisu.sign.repository.RefreshTokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "JwtTokenService")
+public class JwtTokenService {
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Map<String, String> createToken(
+            Long userId, String username, List<String> roles
+    ) {
+
+        String accessToken = jwtUtil.createAccessToken(userId, username, roles);
+        String refreshToken = jwtUtil.createRefreshToken(userId, username, roles);
+
+        refreshTokenRepository.deleteByUserId(userId);
+        refreshTokenRepository.save(new RefreshToken(userId, refreshToken));
+
+        return Map.of("accessToken", accessToken, "refreshToken", refreshToken);
+    }
+
+    public String validateToken(String bearerToken) {
+
+        String tokenValue = jwtUtil.getJwtFromHeader(bearerToken);
+
+        if (!StringUtils.hasText(tokenValue)) {
+            throw new RuntimeException("토큰이 비어 있습니다. 유효하지 않은 Access Token입니다.");
+        }
+
+        if (!jwtUtil.validateToken(tokenValue)) {
+            log.warn("Expired JWT token, 만료된 JWT token 입니다.");
+            return null;
+        }
+
+        return tokenValue;
+    }
+
+    public String renewAccessTokenWithRefreshToken(
+            String refreshToken, CustomUserDetails userDetails
+    ) {
+
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new RuntimeException("만료되었거나 유효하지 않은 Refresh Token입니다.");
+        }
+
+        if (!refreshTokenRepository.existsByRefreshToken(refreshToken)) {
+            throw new RuntimeException("데이터베이스에 존재하지 않는 Refresh Token입니다.");
+        }
+
+        List<String> roles = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        return jwtUtil.createAccessToken(
+                userDetails.getUserId(), userDetails.getUsername(), roles);
+    }
+
+    public String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public void createRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) jwtUtil.getRefreshTokenTime());
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public String getUsernameFromToken(String token) {
+
+        return jwtUtil.getUserInfoFromToken(token).getSubject();
+    }
+}

--- a/src/main/java/com/isuisu/sign/security/JwtUtil.java
+++ b/src/main/java/com/isuisu/sign/security/JwtUtil.java
@@ -1,0 +1,105 @@
+package com.isuisu.sign.security;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+    public static final String CLAIM_KEY_ROLES = "roles";
+    public static final String CLAIM_KEY_USER_ID = "userId";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${security.jwt.secret.key}")
+    private String secretKey;
+
+    @Value("${security.jwt.secret.expiration}")
+    private long accessTokenTime;
+
+    @Value("${security.jwt.refresh.expiration}")
+    private long refreshTokenTime;
+
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public long getRefreshTokenTime() {
+        return refreshTokenTime;
+    }
+
+    public String createAccessToken(Long userId, String username, List<String> roles) {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim(CLAIM_KEY_ROLES, roles)
+                .claim(CLAIM_KEY_USER_ID, userId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusMillis(accessTokenTime)))
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId, String username, List<String> roles) {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim(CLAIM_KEY_ROLES, roles)
+                .claim(CLAIM_KEY_USER_ID, userId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(
+                        now.plus(Duration.ofSeconds(refreshTokenTime))))
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
+    public String getJwtFromHeader(String bearerToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException |
+                 SignatureException e) {
+            throw new RuntimeException("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT token, 만료된 JWT token 입니다.");
+            return false;
+        } catch (UnsupportedJwtException e) {
+            throw new RuntimeException("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+security:
+  jwt:
+    secret:
+      key: ${JWT_SECRET_KEY}
+      expiration: 300000
+    refresh:
+      expiration: 604800


### PR DESCRIPTION
## PR Type
- [x]  Feature
<br>

## Description
- 로그인 기능 구현
  - 로직은 JwtAuthenticationFilter 에서 진행 ( controller 까지 도달하지 않습니다. )

```
1. API 요청 : `POST` /api/signin
2. 사용자 인증 : JwtAuthenticationFilter.attemptAuthentication() 
3. 인증에 성공하면 JSON body 로 access 토큰 발행 : JwtAuthenticationFilter.successfulAuthentication()
4. 로그인 이후 API 요청
5. JWT 검증 및 인가 : JwtAuthorizationFilter
6. access 토큰이 유효하면 SecurityContextHolder 에 저장
7. access 토큰이 유효하지 않으면 쿠키에서 추출한 refresh 토큰으로 access 토큰 재발급 
```

- refresh 토큰 데이터베이스에 저장
- access 토큰은 헤더에 전달 / refresh 토큰은 쿠키로 전달
- access 토큰 만료 5분 / refresh 토큰 만료 1주일